### PR TITLE
Revert "Update ghcr.io/berriai/litellm Docker tag to v1.81.12"

### DIFF
--- a/ares/compose.yml
+++ b/ares/compose.yml
@@ -70,7 +70,7 @@ services:
       retries: 10
   
   litellm:
-    image: ghcr.io/berriai/litellm:v1.81.12-stable
+    image: ghcr.io/berriai/litellm:v1.81.9-stable
     restart: unless-stopped
     depends_on:
       litellm-db:


### PR DESCRIPTION
Reverts nint8835/ops#545

This update breaks cost tracking for image edits (see https://github.com/BerriAI/litellm/issues/22244)